### PR TITLE
add warnings/errors for the compiler:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Changes for supporting c++ excpetions not using directly the seh mechainsm in windows.
-
+Disabling inlining by force
 Change _CxxThrowException and _CxxFrameHandler3 to MyCxxThrowException and MyCxxFrameHandler3.
 
 #### Add a refactoring tool helper - for making it simpler to move from c/ c++ which not throws exceptions to throw c++ exception by adding a noexcept keyword to every function declaration (except extern "C" functions), and then we will get a warning if this function tries to call a function which may raise an exception, so it will be safe always to change a function from state of not throwing, to a state of throwing.
 
 Add the following warnings:
-1) no empty throw - meaning rethrow exception.
+1) No empty throw - meaning rethrow exception.
 ##### for example:
     try
     {
@@ -17,7 +17,7 @@ Add the following warnings:
     }
 will raise an error in compilation time.
 
-2) no catching exception not by refernce, including but not limitied to pointer passing.
+2) No catching exception not by refernce, including but not limitied to pointer passing.
 ##### for example:
     try
     {
@@ -28,7 +28,7 @@ will raise an error in compilation time.
     }
 will raise an error in compilation time.
 
-3) no nested try catch in the same function, and disabling inlining by force.
+3) No nested try catch in the same function.
 ##### for example:
     class m{};
     try
@@ -46,7 +46,7 @@ will raise an error in compilation time.
     }
 will raise an error in compilation time.
 
-4) make sure a noexcept function can not call a function which may throw without the function to be placed under an ellipsis try catch block
+4) Make sure a noexcept function can not call a function which may throw without the function to be placed under an ellipsis try catch block
 ##### for example:
     void f()
     {
@@ -82,110 +82,3 @@ will raise an error in compilation time.
             // empty on purpose.
         }
     }
-will raise an error in compilation time.
-
-
-# The LLVM Compiler Infrastructure
-
-This directory and its subdirectories contain source code for LLVM,
-a toolkit for the construction of highly optimized compilers,
-optimizers, and runtime environments.
-
-## Getting Started with the LLVM System
-
-Taken from https://llvm.org/docs/GettingStarted.html.
-
-### Overview
-
-Welcome to the LLVM project!
-
-The LLVM project has multiple components. The core of the project is
-itself called "LLVM". This contains all of the tools, libraries, and header
-files needed to process intermediate representations and converts it into
-object files.  Tools include an assembler, disassembler, bitcode analyzer, and
-bitcode optimizer.  It also contains basic regression tests.
-
-C-like languages use the [Clang](http://clang.llvm.org/) front end.  This
-component compiles C, C++, Objective C, and Objective C++ code into LLVM bitcode
--- and from there into object files, using LLVM.
-
-Other components include:
-the [libc++ C++ standard library](https://libcxx.llvm.org),
-the [LLD linker](https://lld.llvm.org), and more.
-
-### Getting the Source Code and Building LLVM
-
-The LLVM Getting Started documentation may be out of date.  The [Clang
-Getting Started](http://clang.llvm.org/get_started.html) page might have more
-accurate information.
-
-This is an example workflow and configuration to get and build the LLVM source:
-
-1. Checkout LLVM (including related subprojects like Clang):
-
-     * ``git clone https://github.com/llvm/llvm-project.git``
-
-     * Or, on windows, ``git clone --config core.autocrlf=false
-    https://github.com/llvm/llvm-project.git``
-
-2. Configure and build LLVM and Clang:
-
-     * ``cd llvm-project``
-
-     * ``mkdir build``
-
-     * ``cd build``
-
-     * ``cmake -G <generator> [options] ../llvm``
-
-        Some common generators are:
-
-        * ``Ninja`` --- for generating [Ninja](https://ninja-build.org)
-          build files. Most llvm developers use Ninja.
-        * ``Unix Makefiles`` --- for generating make-compatible parallel makefiles.
-        * ``Visual Studio`` --- for generating Visual Studio projects and
-          solutions.
-        * ``Xcode`` --- for generating Xcode projects.
-
-        Some Common options:
-
-        * ``-DLLVM_ENABLE_PROJECTS='...'`` --- semicolon-separated list of the LLVM
-          subprojects you'd like to additionally build. Can include any of: clang,
-          clang-tools-extra, libcxx, libcxxabi, libunwind, lldb, compiler-rt, lld,
-          polly, or debuginfo-tests.
-
-          For example, to build LLVM, Clang, libcxx, and libcxxabi, use
-          ``-DLLVM_ENABLE_PROJECTS="clang;libcxx;libcxxabi"``.
-
-        * ``-DCMAKE_INSTALL_PREFIX=directory`` --- Specify for *directory* the full
-          pathname of where you want the LLVM tools and libraries to be installed
-          (default ``/usr/local``).
-
-        * ``-DCMAKE_BUILD_TYPE=type`` --- Valid options for *type* are Debug,
-          Release, RelWithDebInfo, and MinSizeRel. Default is Debug.
-
-        * ``-DLLVM_ENABLE_ASSERTIONS=On`` --- Compile with assertion checks enabled
-          (default is Yes for Debug builds, No for all other build types).
-
-      * Run your build tool of choice!
-
-        * The default target (i.e. ``ninja`` or ``make``) will build all of LLVM.
-
-        * The ``check-all`` target (i.e. ``ninja check-all``) will run the
-          regression tests to ensure everything is in working order.
-
-        * CMake will generate build targets for each tool and library, and most
-          LLVM sub-projects generate their own ``check-<project>`` target.
-
-        * Running a serial build will be *slow*.  To improve speed, try running a
-          parallel build. That's done by default in Ninja; for ``make``, use
-          ``make -j NNN`` (NNN is the number of parallel jobs, use e.g. number of
-          CPUs you have.)
-
-      * For more information see [CMake](https://llvm.org/docs/CMake.html)
-
-Consult the
-[Getting Started with LLVM](https://llvm.org/docs/GettingStarted.html#getting-started-with-llvm)
-page for detailed information on configuring and compiling LLVM. You can visit
-[Directory Layout](https://llvm.org/docs/GettingStarted.html#directory-layout)
-to learn about the layout of the source code tree.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Changes for supporting c++ excpetions not using directly the seh mechainsm in windows.
-Disabling inlining by force
-Change _CxxThrowException and _CxxFrameHandler3 to MyCxxThrowException and MyCxxFrameHandler3.
+* Disabling inlining by force.
+* Change _CxxThrowException and _CxxFrameHandler3 to MyCxxThrowException and MyCxxFrameHandler3 (usefull for making it possilbe to use another Crts) .
 
-#### Add a refactoring tool helper - for making it simpler to move from c/ c++ which not throws exceptions to throw c++ exception by adding a noexcept keyword to every function declaration (except extern "C" functions), and then we will get a warning if this function tries to call a function which may raise an exception, so it will be safe always to change a function from state of not throwing, to a state of throwing.
+* #### Add a refactoring tool helper - for making it simpler to move from c/ c++ which not throws exceptions to throw c++ exception by adding a noexcept keyword to every function declaration (except extern "C" functions), and then we will get a warning if this function tries to call a function which may raise an exception, so it will be safe always to change a function from state of not throwing, to a state of throwing.
 
 Add the following warnings:
 1) No empty throw - meaning rethrow exception.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,65 @@
+# Changes for supporting c++ excpetions not based on the seh mechainsm in windows.
+
+Change _CxxThrowException and _CxxFrameHandler3 to MyCxxThrowException and MyCxxFrameHandler3.
+
+#### Add a refactoring tool helper - for making it simpler to move from c/ c++ which not throws exceptions to throw c++ exception by adding a noexcept keyword to every function declaration (except extern "C" functions)
+
+Add the following warnings:
+1) no empty throw - meaning rethrow exception.
+##### for example:
+    try
+    {
+        throw 1;
+    }
+    catch(...)
+    {
+        throw;
+    }
+will raise an error in compilation time.
+
+2) no catching exception not by refernce, including but not limitied to pointer passing.
+##### for example:
+    try
+    {
+        throw 1;
+    }
+    catch(int a)
+    {
+    }
+will raise an error in compilation time.
+
+3) no nested try catch in the same function, and disabling inlining by force.
+##### for example:
+    class m{};
+    try
+    {
+        try
+        {
+            throw m;
+        }
+        catch(int a)
+        {
+        }
+     }
+    catch(...)
+    {
+    }
+will raise an error in compilation time.
+
+4) make sure noexcept function can not call a function which may throw without the function to be placed under try catch
+##### for example:
+    void f()
+    {
+        throw 1;
+    }
+
+    void g() noexcpet()
+    {
+        f();
+    }
+will raise an error in compilation time.
+
+
 # The LLVM Compiler Infrastructure
 
 This directory and its subdirectories contain source code for LLVM,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Change _CxxThrowException and _CxxFrameHandler3 to MyCxxThrowException and MyCxxFrameHandler3.
 
-#### Add a refactoring tool helper - for making it simpler to move from c/ c++ which not throws exceptions to throw c++ exception by adding a noexcept keyword to every function declaration (except extern "C" functions)
+#### Add a refactoring tool helper - for making it simpler to move from c/ c++ which not throws exceptions to throw c++ exception by adding a noexcept keyword to every function declaration (except extern "C" functions), and then we will get a warning if this function tries to call a function which may raise an exception, so it will be safe always to change a function from state of not throwing, to a state of throwing.
 
 Add the following warnings:
 1) no empty throw - meaning rethrow exception.

--- a/README.md
+++ b/README.md
@@ -1,84 +1,83 @@
 # Changes for supporting c++ excpetions not using directly the seh mechainsm in windows.
 * Disabling inlining by force.
 * Change _CxxThrowException and _CxxFrameHandler3 to MyCxxThrowException and MyCxxFrameHandler3 (usefull for making it possilbe to use another Crts) .
-
 * #### Add a refactoring tool helper - for making it simpler to move from c/ c++ which not throws exceptions to throw c++ exception by adding a noexcept keyword to every function declaration (except extern "C" functions), and then we will get a warning if this function tries to call a function which may raise an exception, so it will be safe always to change a function from state of not throwing, to a state of throwing.
 
-Add the following warnings:
+## Added Warnings:
 1) No empty throw - meaning rethrow exception.
-##### for example:
-    try
-    {
-        throw 1;
-    }
-    catch(...)
-    {
-        throw;
-    }
-will raise an error in compilation time.
-
-2) No catching exception not by refernce, including but not limitied to pointer passing.
-##### for example:
-    try
-    {
-        throw 1;
-    }
-    catch(int a)
-    {
-    }
-will raise an error in compilation time.
-
-3) No nested try catch in the same function.
-##### for example:
-    class m{};
-    try
-    {
+    ##### for example:
         try
         {
-            throw m;
+            throw 1;
+        }
+        catch(...)
+        {
+            throw;
+        }
+    will raise an error in compilation time.
+
+2) No catching exception not by refernce, including but not limitied to pointer passing.
+    ##### for example:
+        try
+        {
+            throw 1;
         }
         catch(int a)
         {
         }
-     }
-    catch(...)
-    {
-    }
-will raise an error in compilation time.
+    will raise an error in compilation time.
+
+3) No nested try catch in the same function.
+    ##### for example:
+        class m{};
+        try
+        {
+            try
+            {
+                throw m;
+            }
+            catch(int a)
+            {
+            }
+         }
+        catch(...)
+        {
+        }
+    will raise an error in compilation time.
 
 4) Make sure a noexcept function can not call a function which may throw without the function to be placed under an ellipsis try catch block
-##### for example:
-    void f()
-    {
-        throw 1;
-    }
+    ##### for example:
+        void f()
+        {
+            throw 1;
+        }
 
-    void g() noexcpet()
-    {
-        f();
-    }
-    
-##### you need to replace it to:
-    void f()
-    {
-        throw 1;
-    }
-
-    void g() noexcpet()
-    {
-        try
+        void g() noexcpet()
         {
             f();
         }
-        catch(const int& a)
+
+    ##### you need to replace it to:
+        void f()
         {
-        //  logic
+            throw 1;
         }
-        // For now you must use elipsis (even if you do nothing in this catch), and not catch it by int, although f only throws int
-        // To make sure the error cann't escape the current function, in the futre I may add an option to catch the exceptions by a 
-        // base class exception.
-        catch(...)
+
+        void g() noexcpet()
         {
-            // empty on purpose.
+            try
+            {
+                f();
+            }
+            catch(const int& a)
+            {
+            //  logic
+            }
+            // For now you must use elipsis (even if you do nothing in this catch), and not catch it by int, although f only throws int
+            // To make sure the error cann't escape the current function, in the futre I may add an option to catch the exceptions by a 
+            // base class exception.
+            catch(...)
+            {
+                // empty on purpose.
+            }
         }
-    }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Changes for supporting c++ excpetions not based on the seh mechainsm in windows.
+# Changes for supporting c++ excpetions not using directly the seh mechainsm in windows.
 
 Change _CxxThrowException and _CxxFrameHandler3 to MyCxxThrowException and MyCxxFrameHandler3.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ will raise an error in compilation time.
     }
 will raise an error in compilation time.
 
-4) make sure noexcept function can not call a function which may throw without the function to be placed under try catch
+4) make sure a noexcept function can not call a function which may throw without the function to be placed under an ellipsis try catch block
 ##### for example:
     void f()
     {
@@ -56,6 +56,31 @@ will raise an error in compilation time.
     void g() noexcpet()
     {
         f();
+    }
+    
+##### you need to replace it to:
+    void f()
+    {
+        throw 1;
+    }
+
+    void g() noexcpet()
+    {
+        try
+        {
+            f();
+        }
+        catch(const int& a)
+        {
+        //  logic
+        }
+        // For now you must use elipsis (even if you do nothing in this catch), and not catch it by int, although f only throws int
+        // To make sure the error cann't escape the current function, in the futre I may add an option to catch the exceptions by a 
+        // base class exception.
+        catch(...)
+        {
+            // empty on purpose.
+        }
     }
 will raise an error in compilation time.
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6756,6 +6756,9 @@ def err_objc_exceptions_disabled : Error<
 
 def err_nested_exception_is_not_supported : Error<
   "%0 nested exception in the same function is not supported">;
+def warn_call_function_which_may_throw_in_noexcept_func : Warning<
+  "%0 has a non-throwing exception specification but call a function which may throw">,
+  InGroup<Exceptions>;
 def warn_throw_in_noexcept_func : Warning<
   "%0 has a non-throwing exception specification but can still throw">,
   InGroup<Exceptions>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6753,6 +6753,9 @@ def err_exceptions_disabled : Error<
   "cannot use '%0' with exceptions disabled">;
 def err_objc_exceptions_disabled : Error<
   "cannot use '%0' with Objective-C exceptions disabled">;
+
+def err_nested_exception_is_not_supported : Error<
+  "%0 nested exception in the same function is not supported">;
 def warn_throw_in_noexcept_func : Warning<
   "%0 has a non-throwing exception specification but can still throw">,
   InGroup<Exceptions>;
@@ -6764,6 +6767,10 @@ def err_seh_try_outside_functions : Error<
   "cannot use SEH '__try' in blocks, captured regions, or Obj-C method decls">;
 def err_mixing_cxx_try_seh_try : Error<
   "cannot use C++ 'try' in the same function as SEH '__try'">;
+def err_rethrow_is_not_supported : Error<
+  "empty throw is not supported">;
+  def err_catch_without_reffernce_is_not_supported : Error<
+  "catch without refference is not supported">;
 def err_seh_try_unsupported : Error<
   "SEH '__try' is not supported on this target">;
 def note_conflicting_try_here : Note<

--- a/clang/lib/CodeGen/CGException.cpp
+++ b/clang/lib/CodeGen/CGException.cpp
@@ -108,7 +108,7 @@ EHPersonality::MSVC_except_handler = { "_except_handler3", nullptr };
 const EHPersonality
 EHPersonality::MSVC_C_specific_handler = { "__C_specific_handler", nullptr };
 const EHPersonality
-EHPersonality::MSVC_CxxFrameHandler3 = { "__CxxFrameHandler3", nullptr };
+EHPersonality::MSVC_CxxFrameHandler3 = { "MyCxxFrameHandler3", nullptr };
 const EHPersonality
 EHPersonality::GNU_Wasm_CPlusPlus = { "__gxx_wasm_personality_v0", nullptr };
 

--- a/clang/lib/CodeGen/MicrosoftCXXABI.cpp
+++ b/clang/lib/CodeGen/MicrosoftCXXABI.cpp
@@ -734,7 +734,7 @@ public:
     llvm::FunctionType *FTy =
         llvm::FunctionType::get(CGM.VoidTy, Args, /*isVarArg=*/false);
     llvm::FunctionCallee Throw =
-        CGM.CreateRuntimeFunction(FTy, "_CxxThrowException");
+        CGM.CreateRuntimeFunction(FTy, "MyCxxThrowException");
     // _CxxThrowException is stdcall on 32-bit x86 platforms.
     if (CGM.getTarget().getTriple().getArch() == llvm::Triple::x86) {
       if (auto *Fn = dyn_cast<llvm::Function>(Throw.getCallee()))

--- a/clang/tools/clang-refactor/ClangRefactor.cpp
+++ b/clang/tools/clang-refactor/ClangRefactor.cpp
@@ -1,639 +1,218 @@
-//===--- ClangRefactor.cpp - Clang-based refactoring tool -----------------===//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-///
-/// \file
-/// This file implements a clang-refactor tool that performs various
-/// source transformations.
-///
-//===----------------------------------------------------------------------===//
 
-#include "TestSupport.h"
-#include "clang/Frontend/CommandLineSourceLoc.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/DiagnosticOptions.h"
+#include "clang/Basic/FileManager.h"
+#include "clang/Basic/IdentifierTable.h"
+#include "clang/Basic/LangOptions.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Basic/TokenKinds.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/Refactoring.h"
-#include "clang/Tooling/Refactoring/RefactoringAction.h"
-#include "clang/Tooling/Refactoring/RefactoringOptions.h"
 #include "clang/Tooling/Refactoring/Rename/RenamingAction.h"
+#include "clang/Tooling/Refactoring/Rename/USRFindingAction.h"
+#include "clang/Tooling/ReplacementsYaml.h"
 #include "clang/Tooling/Tooling.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
-#include "llvm/Support/Signals.h"
+#include "llvm/Support/YAMLTraits.h"
 #include "llvm/Support/raw_ostream.h"
 #include <string>
+#include <system_error>
+#include "clang/AST/ExprCXX.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/AST/RecursiveASTVisitor.h"
 
+using namespace std;
 using namespace clang;
-using namespace tooling;
-using namespace refactor;
-namespace cl = llvm::cl;
+using namespace clang::driver;
+using namespace clang::tooling;
+using namespace llvm;
 
-namespace opts {
+std::vector<AtomicChange> Changes;
 
-static cl::OptionCategory CommonRefactorOptions("Refactoring options");
+static bool isNoexcept(const FunctionDecl* FD) {
 
-static cl::opt<bool> Verbose("v", cl::desc("Use verbose output"),
-                             cl::cat(cl::GeneralCategory),
-                             cl::sub(*cl::AllSubCommands));
-
-static cl::opt<bool> Inplace("i", cl::desc("Inplace edit <file>s"),
-                             cl::cat(cl::GeneralCategory),
-                             cl::sub(*cl::AllSubCommands));
-
-} // end namespace opts
-
-namespace {
-
-/// Stores the parsed `-selection` argument.
-class SourceSelectionArgument {
-public:
-  virtual ~SourceSelectionArgument() {}
-
-  /// Parse the `-selection` argument.
-  ///
-  /// \returns A valid argument when the parse succedeed, null otherwise.
-  static std::unique_ptr<SourceSelectionArgument> fromString(StringRef Value);
-
-  /// Prints any additional state associated with the selection argument to
-  /// the given output stream.
-  virtual void print(raw_ostream &OS) {}
-
-  /// Returns a replacement refactoring result consumer (if any) that should
-  /// consume the results of a refactoring operation.
-  ///
-  /// The replacement refactoring result consumer is used by \c
-  /// TestSourceSelectionArgument to inject a test-specific result handling
-  /// logic into the refactoring operation. The test-specific consumer
-  /// ensures that the individual results in a particular test group are
-  /// identical.
-  virtual std::unique_ptr<ClangRefactorToolConsumerInterface>
-  createCustomConsumer() {
-    return nullptr;
-  }
-
-  /// Runs the give refactoring function for each specified selection.
-  ///
-  /// \returns true if an error occurred, false otherwise.
-  virtual bool
-  forAllRanges(const SourceManager &SM,
-               llvm::function_ref<void(SourceRange R)> Callback) = 0;
-};
-
-/// Stores the parsed -selection=test:<filename> option.
-class TestSourceSelectionArgument final : public SourceSelectionArgument {
-public:
-  TestSourceSelectionArgument(TestSelectionRangesInFile TestSelections)
-      : TestSelections(std::move(TestSelections)) {}
-
-  void print(raw_ostream &OS) override { TestSelections.dump(OS); }
-
-  std::unique_ptr<ClangRefactorToolConsumerInterface>
-  createCustomConsumer() override {
-    return TestSelections.createConsumer();
-  }
-
-  /// Testing support: invokes the selection action for each selection range in
-  /// the test file.
-  bool forAllRanges(const SourceManager &SM,
-                    llvm::function_ref<void(SourceRange R)> Callback) override {
-    return TestSelections.foreachRange(SM, Callback);
-  }
-
-private:
-  TestSelectionRangesInFile TestSelections;
-};
-
-/// Stores the parsed -selection=filename:line:column[-line:column] option.
-class SourceRangeSelectionArgument final : public SourceSelectionArgument {
-public:
-  SourceRangeSelectionArgument(ParsedSourceRange Range)
-      : Range(std::move(Range)) {}
-
-  bool forAllRanges(const SourceManager &SM,
-                    llvm::function_ref<void(SourceRange R)> Callback) override {
-    auto FE = SM.getFileManager().getFile(Range.FileName);
-    FileID FID = FE ? SM.translateFile(*FE) : FileID();
-    if (!FE || FID.isInvalid()) {
-      llvm::errs() << "error: -selection=" << Range.FileName
-                   << ":... : given file is not in the target TU\n";
-      return true;
-    }
-
-    SourceLocation Start = SM.getMacroArgExpandedLocation(
-        SM.translateLineCol(FID, Range.Begin.first, Range.Begin.second));
-    SourceLocation End = SM.getMacroArgExpandedLocation(
-        SM.translateLineCol(FID, Range.End.first, Range.End.second));
-    if (Start.isInvalid() || End.isInvalid()) {
-      llvm::errs() << "error: -selection=" << Range.FileName << ':'
-                   << Range.Begin.first << ':' << Range.Begin.second << '-'
-                   << Range.End.first << ':' << Range.End.second
-                   << " : invalid source location\n";
-      return true;
-    }
-    Callback(SourceRange(Start, End));
-    return false;
-  }
-
-private:
-  ParsedSourceRange Range;
-};
-
-std::unique_ptr<SourceSelectionArgument>
-SourceSelectionArgument::fromString(StringRef Value) {
-  if (Value.startswith("test:")) {
-    StringRef Filename = Value.drop_front(strlen("test:"));
-    Optional<TestSelectionRangesInFile> ParsedTestSelection =
-        findTestSelectionRanges(Filename);
-    if (!ParsedTestSelection)
-      return nullptr; // A parsing error was already reported.
-    return std::make_unique<TestSourceSelectionArgument>(
-        std::move(*ParsedTestSelection));
-  }
-  Optional<ParsedSourceRange> Range = ParsedSourceRange::fromString(Value);
-  if (Range)
-    return std::make_unique<SourceRangeSelectionArgument>(std::move(*Range));
-  llvm::errs() << "error: '-selection' option must be specified using "
-                  "<file>:<line>:<column> or "
-                  "<file>:<line>:<column>-<line>:<column> format\n";
-  return nullptr;
+	const auto* FPT = FD->getType()->castAs<FunctionProtoType>();
+	// This is for make sure I can use FPT->isNothrow(), else it will crash the program and for now I don't know why, and the worst case is
+// that a I add noexcept twice.
+	switch (FPT->getExceptionSpecType()) {
+	case EST_Unparsed:
+	case EST_Unevaluated:
+	case EST_Uninstantiated:
+		return false;
+	default:
+		break;
+	}
+	if (FD->hasAttr<NoThrowAttr>() || FPT->isNothrow() || FD->isExternC())
+		return true;
+	return false;
 }
 
-/// A container that stores the command-line options used by a single
-/// refactoring option.
-class RefactoringActionCommandLineOptions {
-public:
-  void addStringOption(const RefactoringOption &Option,
-                       std::unique_ptr<cl::opt<std::string>> CLOption) {
-    StringOptions[&Option] = std::move(CLOption);
-  }
-
-  const cl::opt<std::string> &
-  getStringOption(const RefactoringOption &Opt) const {
-    auto It = StringOptions.find(&Opt);
-    return *It->second;
-  }
-
+class ExampleVisitor : public RecursiveASTVisitor<ExampleVisitor> {
 private:
-  llvm::DenseMap<const RefactoringOption *,
-                 std::unique_ptr<cl::opt<std::string>>>
-      StringOptions;
+	ASTContext *astContext; // used for getting additional AST info
+
+public:
+	explicit ExampleVisitor(CompilerInstance *CI)
+		: astContext(&(CI->getASTContext())) // initialize private members
+	{
+	}
+
+	virtual bool VisitFunctionDecl(FunctionDecl *func) {
+		if (isNoexcept(func) || func->getLocation().isMacroID()  || func->isImplicit())
+		{
+			return true;
+		}
+		auto& SourceManager = astContext->getSourceManager();
+		auto ExpansionLoc = SourceManager.getExpansionLoc(func->getBeginLoc());
+		if (ExpansionLoc.isInvalid()) {
+			return false;
+		}
+		if(SourceManager.isInSystemHeader(ExpansionLoc))
+		{
+			return false;
+		}
+		bool Error = false;
+		std::string text =
+			Lexer::getSourceText(CharSourceRange::getTokenRange(
+				func->getEndLoc()),
+				SourceManager, LangOptions(), &Error);
+		int firstWordStartIndex=0;
+		for( ;firstWordStartIndex< text.size(); firstWordStartIndex++)
+		{
+			if(text[firstWordStartIndex] != '\n' && text[firstWordStartIndex] != '\r' && text[firstWordStartIndex] != ' ' && text[firstWordStartIndex
+				] !='\t')
+			{
+				break;
+			}
+		}
+		if(firstWordStartIndex == text.size())
+		{
+			return true;
+		}
+
+		int wordLastIndex = firstWordStartIndex + 1;
+		for (; wordLastIndex < text.size(); wordLastIndex++)
+		{
+			if (text[wordLastIndex] != '\n' && text[wordLastIndex] != '\r' && text[wordLastIndex] != ' ' && text[wordLastIndex
+			] != '\t' && (text[wordLastIndex] < 'A' || text[wordLastIndex] > 'Z'))
+			{
+				break;
+			}
+		}
+
+		std::string wordAfterFunction = text.substr(firstWordStartIndex, wordLastIndex - firstWordStartIndex);
+		int shouldAddToOffset = firstWordStartIndex;
+		if(wordAfterFunction == ")")
+		{
+			shouldAddToOffset += 1;
+		}
+		else if (wordAfterFunction == "c")
+		{
+			shouldAddToOffset += std::string("const").size();
+		}
+		else if (wordAfterFunction == "t")
+		{
+			shouldAddToOffset -= std::string("= default").size();
+		}
+		else if (wordAfterFunction == "0")
+		{
+			shouldAddToOffset -= std::string("= ").size();
+		}
+		else if(wordAfterFunction == "e")
+		{
+			shouldAddToOffset -= 1;
+		}
+		AtomicChange Change(astContext->getSourceManager(), func->getEndLoc().getLocWithOffset(shouldAddToOffset));
+		
+			
+		Change.insert(astContext->getSourceManager(), func->getEndLoc().getLocWithOffset(shouldAddToOffset),
+			" noexcept ");
+		Changes.push_back(Change);
+		
+		return true;
+	}
+
 };
 
-/// Passes the command-line option values to the options used by a single
-/// refactoring action rule.
-class CommandLineRefactoringOptionVisitor final
-    : public RefactoringOptionVisitor {
-public:
-  CommandLineRefactoringOptionVisitor(
-      const RefactoringActionCommandLineOptions &Options)
-      : Options(Options) {}
 
-  void visit(const RefactoringOption &Opt,
-             Optional<std::string> &Value) override {
-    const cl::opt<std::string> &CLOpt = Options.getStringOption(Opt);
-    if (!CLOpt.getValue().empty()) {
-      Value = CLOpt.getValue();
-      return;
-    }
-    Value = None;
-    if (Opt.isRequired())
-      MissingRequiredOptions.push_back(&Opt);
-  }
 
-  ArrayRef<const RefactoringOption *> getMissingRequiredOptions() const {
-    return MissingRequiredOptions;
-  }
-
+class ExampleASTConsumer : public ASTConsumer {
 private:
-  llvm::SmallVector<const RefactoringOption *, 4> MissingRequiredOptions;
-  const RefactoringActionCommandLineOptions &Options;
-};
+    ExampleVisitor *visitor; // doesn't have to be private
 
-/// Creates the refactoring options used by all the rules in a single
-/// refactoring action.
-class CommandLineRefactoringOptionCreator final
-    : public RefactoringOptionVisitor {
 public:
-  CommandLineRefactoringOptionCreator(
-      cl::OptionCategory &Category, cl::SubCommand &Subcommand,
-      RefactoringActionCommandLineOptions &Options)
-      : Category(Category), Subcommand(Subcommand), Options(Options) {}
+    // override the constructor in order to pass CI
+    explicit ExampleASTConsumer(CompilerInstance *CI)
+        : visitor(new ExampleVisitor(CI)) // initialize the visitor
+    { }
 
-  void visit(const RefactoringOption &Opt, Optional<std::string> &) override {
-    if (Visited.insert(&Opt).second)
-      Options.addStringOption(Opt, create<std::string>(Opt));
-  }
-
-private:
-  template <typename T>
-  std::unique_ptr<cl::opt<T>> create(const RefactoringOption &Opt) {
-    if (!OptionNames.insert(Opt.getName()).second)
-      llvm::report_fatal_error("Multiple identical refactoring options "
-                               "specified for one refactoring action");
-    // FIXME: cl::Required can be specified when this option is present
-    // in all rules in an action.
-    return std::make_unique<cl::opt<T>>(
-        Opt.getName(), cl::desc(Opt.getDescription()), cl::Optional,
-        cl::cat(Category), cl::sub(Subcommand));
-  }
-
-  llvm::SmallPtrSet<const RefactoringOption *, 8> Visited;
-  llvm::StringSet<> OptionNames;
-  cl::OptionCategory &Category;
-  cl::SubCommand &Subcommand;
-  RefactoringActionCommandLineOptions &Options;
-};
-
-/// A subcommand that corresponds to individual refactoring action.
-class RefactoringActionSubcommand : public cl::SubCommand {
-public:
-  RefactoringActionSubcommand(std::unique_ptr<RefactoringAction> Action,
-                              RefactoringActionRules ActionRules,
-                              cl::OptionCategory &Category)
-      : SubCommand(Action->getCommand(), Action->getDescription()),
-        Action(std::move(Action)), ActionRules(std::move(ActionRules)) {
-    // Check if the selection option is supported.
-    for (const auto &Rule : this->ActionRules) {
-      if (Rule->hasSelectionRequirement()) {
-        Selection = std::make_unique<cl::opt<std::string>>(
-            "selection",
-            cl::desc(
-                "The selected source range in which the refactoring should "
-                "be initiated (<file>:<line>:<column>-<line>:<column> or "
-                "<file>:<line>:<column>)"),
-            cl::cat(Category), cl::sub(*this));
-        break;
-      }
-    }
-    // Create the refactoring options.
-    for (const auto &Rule : this->ActionRules) {
-      CommandLineRefactoringOptionCreator OptionCreator(Category, *this,
-                                                        Options);
-      Rule->visitRefactoringOptions(OptionCreator);
-    }
-  }
-
-  ~RefactoringActionSubcommand() { unregisterSubCommand(); }
-
-  const RefactoringActionRules &getActionRules() const { return ActionRules; }
-
-  /// Parses the "-selection" command-line argument.
-  ///
-  /// \returns true on error, false otherwise.
-  bool parseSelectionArgument() {
-    if (Selection) {
-      ParsedSelection = SourceSelectionArgument::fromString(*Selection);
-      if (!ParsedSelection)
-        return true;
-    }
-    return false;
-  }
-
-  SourceSelectionArgument *getSelection() const {
-    assert(Selection && "selection not supported!");
-    return ParsedSelection.get();
-  }
-
-  const RefactoringActionCommandLineOptions &getOptions() const {
-    return Options;
-  }
-
-private:
-  std::unique_ptr<RefactoringAction> Action;
-  RefactoringActionRules ActionRules;
-  std::unique_ptr<cl::opt<std::string>> Selection;
-  std::unique_ptr<SourceSelectionArgument> ParsedSelection;
-  RefactoringActionCommandLineOptions Options;
-};
-
-class ClangRefactorConsumer final : public ClangRefactorToolConsumerInterface {
-public:
-  ClangRefactorConsumer(AtomicChanges &Changes) : SourceChanges(&Changes) {}
-
-  void handleError(llvm::Error Err) override {
-    Optional<PartialDiagnosticAt> Diag = DiagnosticError::take(Err);
-    if (!Diag) {
-      llvm::errs() << llvm::toString(std::move(Err)) << "\n";
-      return;
-    }
-    llvm::cantFail(std::move(Err)); // This is a success.
-    DiagnosticBuilder DB(
-        getDiags().Report(Diag->first, Diag->second.getDiagID()));
-    Diag->second.Emit(DB);
-  }
-
-  void handle(AtomicChanges Changes) override {
-    SourceChanges->insert(SourceChanges->begin(), Changes.begin(),
-                          Changes.end());
-  }
-
-  void handle(SymbolOccurrences Occurrences) override {
-    llvm_unreachable("symbol occurrence results are not handled yet");
-  }
-
-private:
-  AtomicChanges *SourceChanges;
-};
-
-class ClangRefactorTool {
-public:
-  ClangRefactorTool()
-      : SelectedSubcommand(nullptr), MatchingRule(nullptr),
-        Consumer(new ClangRefactorConsumer(Changes)), HasFailed(false) {
-    std::vector<std::unique_ptr<RefactoringAction>> Actions =
-        createRefactoringActions();
-
-    // Actions must have unique command names so that we can map them to one
-    // subcommand.
-    llvm::StringSet<> CommandNames;
-    for (const auto &Action : Actions) {
-      if (!CommandNames.insert(Action->getCommand()).second) {
-        llvm::errs() << "duplicate refactoring action command '"
-                     << Action->getCommand() << "'!";
-        exit(1);
-      }
+    // override this to call our ExampleVisitor on the entire source file
+    virtual void HandleTranslationUnit(ASTContext &Context) {
+        /* we can use ASTContext to get the TranslationUnitDecl, which is
+             a single Decl that collectively represents the entire source file */
+        visitor->TraverseDecl(Context.getTranslationUnitDecl());
     }
 
-    // Create subcommands and command-line options.
-    for (auto &Action : Actions) {
-      SubCommands.push_back(std::make_unique<RefactoringActionSubcommand>(
-          std::move(Action), Action->createActiveActionRules(),
-          opts::CommonRefactorOptions));
-    }
-  }
-
-  // Initializes the selected subcommand and refactoring rule based on the
-  // command line options.
-  llvm::Error Init() {
-    auto Subcommand = getSelectedSubcommand();
-    if (!Subcommand)
-      return Subcommand.takeError();
-    auto Rule = getMatchingRule(**Subcommand);
-    if (!Rule)
-      return Rule.takeError();
-
-    SelectedSubcommand = *Subcommand;
-    MatchingRule = *Rule;
-
-    return llvm::Error::success();
-  }
-
-  bool hasFailed() const { return HasFailed; }
-
-  using TUCallbackType = std::function<void(ASTContext &)>;
-
-  // Callback of an AST action. This invokes the matching rule on the given AST.
-  void callback(ASTContext &AST) {
-    assert(SelectedSubcommand && MatchingRule && Consumer);
-    RefactoringRuleContext Context(AST.getSourceManager());
-    Context.setASTContext(AST);
-
-    // If the selection option is test specific, we use a test-specific
-    // consumer.
-    std::unique_ptr<ClangRefactorToolConsumerInterface> TestConsumer;
-    bool HasSelection = MatchingRule->hasSelectionRequirement();
-    if (HasSelection)
-      TestConsumer = SelectedSubcommand->getSelection()->createCustomConsumer();
-    ClangRefactorToolConsumerInterface *ActiveConsumer =
-        TestConsumer ? TestConsumer.get() : Consumer.get();
-    ActiveConsumer->beginTU(AST);
-
-    auto InvokeRule = [&](RefactoringResultConsumer &Consumer) {
-      if (opts::Verbose)
-        logInvocation(*SelectedSubcommand, Context);
-      MatchingRule->invoke(*ActiveConsumer, Context);
-    };
-    if (HasSelection) {
-      assert(SelectedSubcommand->getSelection() &&
-             "Missing selection argument?");
-      if (opts::Verbose)
-        SelectedSubcommand->getSelection()->print(llvm::outs());
-      if (SelectedSubcommand->getSelection()->forAllRanges(
-              Context.getSources(), [&](SourceRange R) {
-                Context.setSelectionRange(R);
-                InvokeRule(*ActiveConsumer);
-              }))
-        HasFailed = true;
-      ActiveConsumer->endTU();
-      return;
-    }
-    InvokeRule(*ActiveConsumer);
-    ActiveConsumer->endTU();
-  }
-
-  llvm::Expected<std::unique_ptr<FrontendActionFactory>>
-  getFrontendActionFactory() {
-    class ToolASTConsumer : public ASTConsumer {
-    public:
-      TUCallbackType Callback;
-      ToolASTConsumer(TUCallbackType Callback)
-          : Callback(std::move(Callback)) {}
-
-      void HandleTranslationUnit(ASTContext &Context) override {
-        Callback(Context);
-      }
-    };
-    class ToolASTAction : public ASTFrontendAction {
-    public:
-      explicit ToolASTAction(TUCallbackType Callback)
-          : Callback(std::move(Callback)) {}
-
-    protected:
-      std::unique_ptr<clang::ASTConsumer>
-      CreateASTConsumer(clang::CompilerInstance &compiler,
-                        StringRef /* dummy */) override {
-        std::unique_ptr<clang::ASTConsumer> Consumer{
-            new ToolASTConsumer(Callback)};
-        return Consumer;
-      }
-
-    private:
-      TUCallbackType Callback;
-    };
-
-    class ToolActionFactory : public FrontendActionFactory {
-    public:
-      ToolActionFactory(TUCallbackType Callback)
-          : Callback(std::move(Callback)) {}
-
-      std::unique_ptr<FrontendAction> create() override {
-        return std::make_unique<ToolASTAction>(Callback);
-      }
-
-    private:
-      TUCallbackType Callback;
-    };
-
-    return std::make_unique<ToolActionFactory>(
-        [this](ASTContext &AST) { return callback(AST); });
-  }
-
-  // FIXME(ioeric): this seems to only works for changes in a single file at
-  // this point.
-  bool applySourceChanges() {
-    std::set<std::string> Files;
-    for (const auto &Change : Changes)
-      Files.insert(Change.getFilePath());
-    // FIXME: Add automatic formatting support as well.
-    tooling::ApplyChangesSpec Spec;
-    // FIXME: We should probably cleanup the result by default as well.
-    Spec.Cleanup = false;
-    for (const auto &File : Files) {
-      llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> BufferErr =
-          llvm::MemoryBuffer::getFile(File);
-      if (!BufferErr) {
-        llvm::errs() << "error: failed to open " << File << " for rewriting\n";
-        return true;
-      }
-      auto Result = tooling::applyAtomicChanges(File, (*BufferErr)->getBuffer(),
-                                                Changes, Spec);
-      if (!Result) {
-        llvm::errs() << toString(Result.takeError());
-        return true;
-      }
-
-      if (opts::Inplace) {
-        std::error_code EC;
-        llvm::raw_fd_ostream OS(File, EC, llvm::sys::fs::OF_Text);
-        if (EC) {
-          llvm::errs() << EC.message() << "\n";
-          return true;
+/*
+    // override this to call our ExampleVisitor on each top-level Decl
+    virtual bool HandleTopLevelDecl(DeclGroupRef DG) {
+        // a DeclGroupRef may have multiple Decls, so we iterate through each one
+        for (DeclGroupRef::iterator i = DG.begin(), e = DG.end(); i != e; i++) {
+            Decl *D = *i;    
+            visitor->TraverseDecl(D); // recursively visit each AST node in Decl "D"
         }
-        OS << *Result;
-        continue;
-      }
-
-      llvm::outs() << *Result;
+        return true;
     }
-    return false;
-  }
-
-private:
-  /// Logs an individual refactoring action invocation to STDOUT.
-  void logInvocation(RefactoringActionSubcommand &Subcommand,
-                     const RefactoringRuleContext &Context) {
-    llvm::outs() << "invoking action '" << Subcommand.getName() << "':\n";
-    if (Context.getSelectionRange().isValid()) {
-      SourceRange R = Context.getSelectionRange();
-      llvm::outs() << "  -selection=";
-      R.getBegin().print(llvm::outs(), Context.getSources());
-      llvm::outs() << " -> ";
-      R.getEnd().print(llvm::outs(), Context.getSources());
-      llvm::outs() << "\n";
-    }
-  }
-
-  llvm::Expected<RefactoringActionRule *>
-  getMatchingRule(RefactoringActionSubcommand &Subcommand) {
-    SmallVector<RefactoringActionRule *, 4> MatchingRules;
-    llvm::StringSet<> MissingOptions;
-
-    for (const auto &Rule : Subcommand.getActionRules()) {
-      CommandLineRefactoringOptionVisitor Visitor(Subcommand.getOptions());
-      Rule->visitRefactoringOptions(Visitor);
-      if (Visitor.getMissingRequiredOptions().empty()) {
-        if (!Rule->hasSelectionRequirement()) {
-          MatchingRules.push_back(Rule.get());
-        } else {
-          Subcommand.parseSelectionArgument();
-          if (Subcommand.getSelection()) {
-            MatchingRules.push_back(Rule.get());
-          } else {
-            MissingOptions.insert("selection");
-          }
-        }
-      }
-      for (const RefactoringOption *Opt : Visitor.getMissingRequiredOptions())
-        MissingOptions.insert(Opt->getName());
-    }
-    if (MatchingRules.empty()) {
-      std::string Error;
-      llvm::raw_string_ostream OS(Error);
-      OS << "ERROR: '" << Subcommand.getName()
-         << "' can't be invoked with the given arguments:\n";
-      for (const auto &Opt : MissingOptions)
-        OS << "  missing '-" << Opt.getKey() << "' option\n";
-      OS.flush();
-      return llvm::make_error<llvm::StringError>(
-          Error, llvm::inconvertibleErrorCode());
-    }
-    if (MatchingRules.size() != 1) {
-      return llvm::make_error<llvm::StringError>(
-          llvm::Twine("ERROR: more than one matching rule of action") +
-              Subcommand.getName() + "was found with given options.",
-          llvm::inconvertibleErrorCode());
-    }
-    return MatchingRules.front();
-  }
-  // Figure out which action is specified by the user. The user must specify the
-  // action using a command-line subcommand, e.g. the invocation `clang-refactor
-  // local-rename` corresponds to the `LocalRename` refactoring action. All
-  // subcommands must have a unique names. This allows us to figure out which
-  // refactoring action should be invoked by looking at the first subcommand
-  // that's enabled by LLVM's command-line parser.
-  llvm::Expected<RefactoringActionSubcommand *> getSelectedSubcommand() {
-    auto It = llvm::find_if(
-        SubCommands,
-        [](const std::unique_ptr<RefactoringActionSubcommand> &SubCommand) {
-          return !!(*SubCommand);
-        });
-    if (It == SubCommands.end()) {
-      std::string Error;
-      llvm::raw_string_ostream OS(Error);
-      OS << "error: no refactoring action given\n";
-      OS << "note: the following actions are supported:\n";
-      for (const auto &Subcommand : SubCommands)
-        OS.indent(2) << Subcommand->getName() << "\n";
-      OS.flush();
-      return llvm::make_error<llvm::StringError>(
-          Error, llvm::inconvertibleErrorCode());
-    }
-    RefactoringActionSubcommand *Subcommand = &(**It);
-    return Subcommand;
-  }
-
-  std::vector<std::unique_ptr<RefactoringActionSubcommand>> SubCommands;
-  RefactoringActionSubcommand *SelectedSubcommand;
-  RefactoringActionRule *MatchingRule;
-  std::unique_ptr<ClangRefactorToolConsumerInterface> Consumer;
-  AtomicChanges Changes;
-  bool HasFailed;
+*/
 };
 
-} // end anonymous namespace
+
+
+class ExampleFrontendAction : public ASTFrontendAction {
+public:
+    virtual std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI, StringRef file) {
+        return std::make_unique<ExampleASTConsumer>(&CI); // pass CI pointer to ASTConsumer
+    }
+};
+
+static cl::OptionCategory MyToolCategory("My tool options");
 
 int main(int argc, const char **argv) {
-  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
+    // parse the command-line args passed to your code
+    CommonOptionsParser op(argc, argv, MyToolCategory);        
+    // create a new Clang Tool instance (a LibTooling environment)
+    ClangTool Tool(op.getCompilations(), op.getSourcePathList());
 
-  ClangRefactorTool RefactorTool;
+    // run the Clang Tool, creating a new FrontendAction (explained below)
+    int result = Tool.run(newFrontendActionFactory<ExampleFrontendAction>().get());
+	std::string ExportFixes = "c:\\temp\\b\\a.yaml";
+	if (!ExportFixes.empty()) {
+		std::error_code EC;
+		llvm::raw_fd_ostream OS(ExportFixes, EC, llvm::sys::fs::OF_None);
+		if (EC) {
+			llvm::errs() << "Error opening output file: " << EC.message() << '\n';
+			return 1;
+		}
+		// Export replacements.
+		tooling::TranslationUnitReplacements TUR;
+		std::vector<Replacement> replacements;
+		for (auto& change: Changes)
+		{
+			for(auto& replacement : change.getReplacements())
+			{
+				replacements.push_back(replacement);
+			}
+		}
+		TUR.Replacements.insert(TUR.Replacements.end(), replacements.begin(),
+			replacements.end());
 
-  CommonOptionsParser Options(
-      argc, argv, cl::GeneralCategory, cl::ZeroOrMore,
-      "Clang-based refactoring tool for C, C++ and Objective-C");
-
-  if (auto Err = RefactorTool.Init()) {
-    llvm::errs() << llvm::toString(std::move(Err)) << "\n";
-    return 1;
-  }
-
-  auto ActionFactory = RefactorTool.getFrontendActionFactory();
-  if (!ActionFactory) {
-    llvm::errs() << llvm::toString(ActionFactory.takeError()) << "\n";
-    return 1;
-  }
-  ClangTool Tool(Options.getCompilations(), Options.getSourcePathList());
-  bool Failed = false;
-  if (Tool.run(ActionFactory->get()) != 0) {
-    llvm::errs() << "Failed to run refactoring action on files\n";
-    // It is possible that TUs are broken while changes are generated correctly,
-    // so we still try applying changes.
-    Failed = true;
-  }
-  return RefactorTool.applySourceChanges() || Failed ||
-         RefactorTool.hasFailed();
+	    llvm::yaml::Output YAML(OS);
+		YAML << TUR;
+		OS.close();
+		return result;
+	}
 }

--- a/llvm/lib/Analysis/EHPersonalities.cpp
+++ b/llvm/lib/Analysis/EHPersonalities.cpp
@@ -35,7 +35,7 @@ EHPersonality llvm::classifyEHPersonality(const Value *Pers) {
     .Case("_except_handler3",          EHPersonality::MSVC_X86SEH)
     .Case("_except_handler4",          EHPersonality::MSVC_X86SEH)
     .Case("__C_specific_handler",      EHPersonality::MSVC_Win64SEH)
-    .Case("__CxxFrameHandler3",        EHPersonality::MSVC_CXX)
+    .Case("MyCxxFrameHandler3",        EHPersonality::MSVC_CXX)
     .Case("ProcessCLRException",       EHPersonality::CoreCLR)
     .Case("rust_eh_personality",       EHPersonality::Rust)
     .Case("__gxx_wasm_personality_v0", EHPersonality::Wasm_CXX)
@@ -52,7 +52,7 @@ StringRef llvm::getEHPersonalityName(EHPersonality Pers) {
   case EHPersonality::GNU_ObjC:      return "__objc_personality_v0";
   case EHPersonality::MSVC_X86SEH:   return "_except_handler3";
   case EHPersonality::MSVC_Win64SEH: return "__C_specific_handler";
-  case EHPersonality::MSVC_CXX:      return "__CxxFrameHandler3";
+  case EHPersonality::MSVC_CXX:      return "MyCxxFrameHandler3";
   case EHPersonality::CoreCLR:       return "ProcessCLRException";
   case EHPersonality::Rust:          return "rust_eh_personality";
   case EHPersonality::Wasm_CXX:      return "__gxx_wasm_personality_v0";

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -1538,6 +1538,7 @@ llvm::InlineResult llvm::InlineFunction(CallSite CS, InlineFunctionInfo &IFI,
                                         AAResults *CalleeAAR,
                                         bool InsertLifetime,
                                         Function *ForwardVarArgsTo) {
+  return "Not supporting inlining for exceptions for now";
   Instruction *TheCall = CS.getInstruction();
   assert(TheCall->getParent() && TheCall->getFunction()
          && "Instruction not in function!");


### PR DESCRIPTION
1) no empty throw - meaning rethrow exception.
2) no catching exception not by refernce, including but not limitied to pointer.
3) no nested try catch in the same function, and disabling inlining by force.
4) make sure noexcept function can not call a function which may throw without the function to be placed under try catch

Also add a refactoring tool instead of ClangRefactor, which will add to all the declarations a noexcpt keyword.
Also change _CxxThrowException and __CxxFrameHandler3 to MyCxxThrowException  and MyCxxFrameHandler3.